### PR TITLE
Cleaning up accent marks + version 

### DIFF
--- a/paper/alchemical.bib
+++ b/paper/alchemical.bib
@@ -5214,7 +5214,7 @@ year = {2016}
 
 @article{perthold2020toward,
   title={Toward automated free energy calculation with accelerated enveloping distribution sampling (A-EDS)},
-  author={Perthold, Jan Walther and Petrov, Dražen and Oostenbrink, Chris},
+  author={Perthold, Jan Walther and Petrov, Dra\v{z}en and Oostenbrink, Chris},
   journal={Journal of Chemical Information and Modeling},
   volume={60},
   number={11},
@@ -5318,7 +5318,7 @@ year = {2016}
 
 @article{hub2014pme,
   title={Quantifying artifacts in Ewald simulations of inhomogeneous systems with a net charge},
-  author={Hub, Jochen S and De Groot, Bert L and Grubmüller, Helmut and Groenhof, Gerrit},
+  author={Hub, Jochen S and De Groot, Bert L and Grubm\"{u}ller, Helmut and Groenhof, Gerrit},
   journal={Journal of chemical theory and computation},
   volume={10},
   number={1},

--- a/paper/manuscript.tex
+++ b/paper/manuscript.tex
@@ -3,7 +3,7 @@
 %%% ADAPTED FROM ELIFE ARTICLE TEMPLATE (8/10/2017)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% PREAMBLE
-\documentclass[9pt,bestpractices,ASAPversion]{livecoms}
+\documentclass[9pt,bestpractices]{livecoms}
 % Use the 'onehalfspacing' option for 1.5 line spacing
 % Use the 'doublespacing' option for 2.0 line spacing
 % Use the 'lineno' option for adding line numbers.

--- a/paper/manuscript.tex
+++ b/paper/manuscript.tex
@@ -3,7 +3,7 @@
 %%% ADAPTED FROM ELIFE ARTICLE TEMPLATE (8/10/2017)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% PREAMBLE
-\documentclass[9pt,bestpractices,pubversion]{livecoms}
+\documentclass[9pt,bestpractices,ASAPversion]{livecoms}
 % Use the 'onehalfspacing' option for 1.5 line spacing
 % Use the 'doublespacing' option for 2.0 line spacing
 % Use the 'lineno' option for adding line numbers.


### PR DESCRIPTION
Cleaning up some accent marks that prevented local compilation.  They probably should be fixed in zotero, but I'm not sure how the references are being managed this time?   I also removed the pubversion flag, which was causing some issues with definitions on compilation, this can be readded when we are removing all the extra nodes.  